### PR TITLE
feat: Rename showUsage to getUsage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ All the flags that are given on the command line to the parent command are hande
 
 By default, all commands automatically come with a `--help` flag. Additionally, every application automatically gets a dedicated `help` command that you can use to show help for each command.
 
-Sometimes you may want to show the usage manually from within a command. For that, add the parameters `showUsage` and `ancestors` to your `handle` function, run the `showUsage` function and hand over an array containing the path to the name of the current command. You may use the `ancestors` array to get the list of names of the parent commands:
+Sometimes you may want to show the usage manually from within a command. For that, add the parameters `getUsage` and `ancestors` to your `handle` function, run the `getUsage` function and hand over an array containing the path to the name of the current command. You may use the `ancestors` array to get the list of names of the parent commands:
 
 ```javascript
 const hello = {
@@ -184,8 +184,8 @@ const hello = {
     // ...
   ],
 
-  handle ({ options, showUsage, ancestors }) {
-    console.log(showUsage([ ...ancestors, 'hello' ]));
+  handle ({ options, getUsage, ancestors }) {
+    console.log(getUsage([ ...ancestors, 'hello' ]));
   }
 };
 ```

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -14,17 +14,17 @@ const helpCommand: Command<HelpOptions> = {
     }
   ],
   ignoreUnknownOptions: true,
-  handle ({ options, showUsage, ancestors }): void {
+  handle ({ options, getUsage, ancestors }): void {
     if (options.command) {
       /* eslint-disable no-console */
-      console.log(showUsage({ commandPath: [ ...ancestors, ...options.command ]}));
+      console.log(getUsage({ commandPath: [ ...ancestors, ...options.command ]}));
       /* eslint-enable no-console */
 
       return;
     }
 
     /* eslint-disable no-console */
-    console.log(showUsage({ commandPath: ancestors }));
+    console.log(getUsage({ commandPath: ancestors }));
     /* eslint-enable no-console */
   }
 };

--- a/lib/elements/CommandHandleOptions.ts
+++ b/lib/elements/CommandHandleOptions.ts
@@ -1,9 +1,9 @@
 import { CommandPath } from './CommandPath';
-import { ShowUsageFn } from './ShowUsageFn';
+import { GetUsageFn } from './GetUsageFn';
 
 export interface CommandHandleOptions<TOptions extends {}> {
   options: TOptions;
-  showUsage: ShowUsageFn;
+  getUsage: GetUsageFn;
   level: number;
   ancestors: CommandPath;
 }

--- a/lib/elements/GetUsageFn.ts
+++ b/lib/elements/GetUsageFn.ts
@@ -1,5 +1,5 @@
 import { CommandPath } from './CommandPath';
 
-export type ShowUsageFn = (params: {
+export type GetUsageFn = (params: {
   commandPath: CommandPath;
 }) => string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,9 +2,9 @@ import { Command } from './elements/Command';
 import { CommandHandle } from './elements/CommandHandle';
 import { CommandHandleOptions } from './elements/CommandHandleOptions';
 import { CommandPath } from './elements/CommandPath';
+import { GetUsageFn } from './elements/GetUsageFn';
 import { OptionDefinition } from './elements/OptionDefinition';
 import { runCli } from './runCli';
-import { GetUsageFn } from './elements/GetUsageFn';
 
 export {
   runCli,
@@ -12,6 +12,6 @@ export {
   CommandHandle,
   CommandHandleOptions,
   CommandPath,
-  OptionDefinition,
-  GetUsageFn
+  GetUsageFn,
+  OptionDefinition
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@ import { CommandHandleOptions } from './elements/CommandHandleOptions';
 import { CommandPath } from './elements/CommandPath';
 import { OptionDefinition } from './elements/OptionDefinition';
 import { runCli } from './runCli';
-import { ShowUsageFn } from './elements/ShowUsageFn';
+import { GetUsageFn } from './elements/GetUsageFn';
 
 export {
   runCli,
@@ -13,5 +13,5 @@ export {
   CommandHandleOptions,
   CommandPath,
   OptionDefinition,
-  ShowUsageFn
+  GetUsageFn
 };

--- a/lib/runCli.ts
+++ b/lib/runCli.ts
@@ -1,7 +1,7 @@
 import { addHelpCommandToCli } from './addHelpCommandToCli';
 import { Command } from './elements/Command';
-import { getRecommendCommand } from './recommend/getRecommendCommand';
 import { getGetUsage } from './usage/getGetUsage';
+import { getRecommendCommand } from './recommend/getRecommendCommand';
 import { runCliRecursive } from './runCliRecursive';
 
 const runCli = async function ({ rootCommand, argv }: {

--- a/lib/runCli.ts
+++ b/lib/runCli.ts
@@ -1,7 +1,7 @@
 import { addHelpCommandToCli } from './addHelpCommandToCli';
 import { Command } from './elements/Command';
 import { getRecommendCommand } from './recommend/getRecommendCommand';
-import { getShowUsage } from './usage/getShowUsage';
+import { getGetUsage } from './usage/getGetUsage';
 import { runCliRecursive } from './runCliRecursive';
 
 const runCli = async function ({ rootCommand, argv }: {
@@ -11,12 +11,12 @@ const runCli = async function ({ rootCommand, argv }: {
   const extendedRootCommand = addHelpCommandToCli({ rootCommand });
 
   const recommendCommand = getRecommendCommand({ rootCommand: extendedRootCommand });
-  const showUsage = getShowUsage({ rootCommand: extendedRootCommand });
+  const getUsage = getGetUsage({ rootCommand: extendedRootCommand });
 
   await runCliRecursive({
     command: extendedRootCommand,
     argv,
-    showUsage,
+    getUsage,
     recommendCommand,
     level: 0,
     ancestorOptions: {},

--- a/lib/runCliRecursive.ts
+++ b/lib/runCliRecursive.ts
@@ -4,13 +4,13 @@ import { CommandPath } from './elements/CommandPath';
 import { convertOptionDefinition } from './convertOptionDefinition';
 import { helpOption } from './commands/helpOption';
 import { RecommendCommandFn } from './elements/RecommendCommandFn';
-import { ShowUsageFn } from './elements/ShowUsageFn';
+import { GetUsageFn } from './elements/GetUsageFn';
 import commandLineArgs, { OptionDefinition as CLAOptionDefinition } from 'command-line-args';
 
 const runCliRecursive = async function ({
   command,
   argv,
-  showUsage,
+  getUsage,
   recommendCommand,
   level,
   ancestorOptions,
@@ -18,7 +18,7 @@ const runCliRecursive = async function ({
 }: {
   command: Command<any>;
   argv: string[];
-  showUsage: ShowUsageFn;
+  getUsage: GetUsageFn;
   recommendCommand: RecommendCommandFn;
   level: number;
   ancestorOptions: Record<string, any>;
@@ -37,7 +37,7 @@ const runCliRecursive = async function ({
 
   if (options.help) {
     /* eslint-disable no-console */
-    console.log(showUsage({ commandPath }));
+    console.log(getUsage({ commandPath }));
     /* eslint-enable no-console */
 
     return;
@@ -52,7 +52,7 @@ const runCliRecursive = async function ({
     try {
       return await command.handle({
         options: mergedOptions,
-        showUsage,
+        getUsage,
         level,
         ancestors: ancestorNames
       });
@@ -94,7 +94,7 @@ const runCliRecursive = async function ({
     return await runCliRecursive({
       command: subCommand,
       argv: subArgv,
-      showUsage,
+      getUsage,
       recommendCommand,
       level: level + 1,
       ancestorOptions: mergedOptions,

--- a/lib/runCliRecursive.ts
+++ b/lib/runCliRecursive.ts
@@ -2,9 +2,9 @@ import { Command } from './elements/Command';
 import commandLineCommands from 'command-line-commands';
 import { CommandPath } from './elements/CommandPath';
 import { convertOptionDefinition } from './convertOptionDefinition';
+import { GetUsageFn } from './elements/GetUsageFn';
 import { helpOption } from './commands/helpOption';
 import { RecommendCommandFn } from './elements/RecommendCommandFn';
-import { GetUsageFn } from './elements/GetUsageFn';
 import commandLineArgs, { OptionDefinition as CLAOptionDefinition } from 'command-line-args';
 
 const runCliRecursive = async function ({

--- a/lib/usage/getGetUsage.ts
+++ b/lib/usage/getGetUsage.ts
@@ -1,11 +1,11 @@
 import { Command } from '../elements/Command';
 import commandLineUsage from 'command-line-usage';
 import { getCommandLineUsageConfiguration } from './getCommandLineUsageConfiguration';
-import { ShowUsageFn } from '../elements/ShowUsageFn';
+import { GetUsageFn } from '../elements/GetUsageFn';
 
-const getShowUsage = function ({ rootCommand }: {
+const getGetUsage = function ({ rootCommand }: {
   rootCommand: Command<any>;
-}): ShowUsageFn {
+}): GetUsageFn {
   return ({ commandPath }): string => {
     const commandLineUsageConfiguration = getCommandLineUsageConfiguration({ rootCommand, commandPath });
 
@@ -13,4 +13,4 @@ const getShowUsage = function ({ rootCommand }: {
   };
 };
 
-export { getShowUsage };
+export { getGetUsage };

--- a/test/integration/runCliTests.ts
+++ b/test/integration/runCliTests.ts
@@ -1,7 +1,7 @@
 import { addHelpCommandToCli } from '../../lib/addHelpCommandToCli';
 import { assert } from 'assertthat';
 import { docker } from '../shared/examples/docker/commands/docker';
-import { getShowUsage } from '../../lib/usage/getShowUsage';
+import { getGetUsage } from '../../lib/usage/getGetUsage';
 import { record } from 'record-stdstreams';
 import { runCli } from '../../lib/runCli';
 import sinon, { SinonStub } from 'sinon';
@@ -73,7 +73,7 @@ suite('Cli', (): void => {
         const { stderr, stdout } = stop();
 
         assert.that(stderr).is.equalTo('');
-        assert.that(stdout).is.equalTo(`${getShowUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker' ]})}\n`);
+        assert.that(stdout).is.equalTo(`${getGetUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker' ]})}\n`);
       });
 
       test('displays the top level help with --help flag, even if a subcommand is given.', async (): Promise<void> => {
@@ -84,7 +84,7 @@ suite('Cli', (): void => {
         const { stderr, stdout } = stop();
 
         assert.that(stderr).is.equalTo('');
-        assert.that(stdout).is.equalTo(`${getShowUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker' ]})}\n`);
+        assert.that(stdout).is.equalTo(`${getGetUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker' ]})}\n`);
       });
 
       test('suggests alternatives and returns status code 1 if subcommands exist and the given command is not recognized.', async (): Promise<void> => {
@@ -259,7 +259,7 @@ suite('Cli', (): void => {
           const { stderr, stdout } = stop();
 
           assert.that(stderr).is.equalTo('');
-          assert.that(stdout).is.equalTo(`${getShowUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker' ]})}\n`);
+          assert.that(stdout).is.equalTo(`${getGetUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker' ]})}\n`);
         });
 
         test('displays the help of the given command.', async (): Promise<void> => {
@@ -270,7 +270,7 @@ suite('Cli', (): void => {
           const { stderr, stdout } = stop();
 
           assert.that(stderr).is.equalTo('');
-          assert.that(stdout).is.equalTo(`${getShowUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker', 'image' ]})}\n`);
+          assert.that(stdout).is.equalTo(`${getGetUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker', 'image' ]})}\n`);
         });
 
         test('displays the help of the given multi-level command.', async (): Promise<void> => {
@@ -281,7 +281,7 @@ suite('Cli', (): void => {
           const { stderr, stdout } = stop();
 
           assert.that(stderr).is.equalTo('');
-          assert.that(stdout).is.equalTo(`${getShowUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker', 'image', 'ls' ]})}\n`);
+          assert.that(stdout).is.equalTo(`${getGetUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker', 'image', 'ls' ]})}\n`);
         });
 
         test('displays the help for the help command if the help flag is set.', async (): Promise<void> => {
@@ -292,7 +292,7 @@ suite('Cli', (): void => {
           const { stderr, stdout } = stop();
 
           assert.that(stderr).is.equalTo('');
-          assert.that(stdout).is.equalTo(`${getShowUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker', 'help' ]})}\n`);
+          assert.that(stdout).is.equalTo(`${getGetUsage({ rootCommand: extendedBuilderCli })({ commandPath: [ 'docker', 'help' ]})}\n`);
         });
       });
     });


### PR DESCRIPTION
BREAKING CHANGE: The `showUsage` function is now `getUsage` to better reflect that it returns the usage as a string, instead of directly printing it.