### PR TITLE
fix: Remove ambiguity of multiple-options by not using "greedy" options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,7 @@ As you have already seen, you can define options for commands. An option needs t
 
 Additionally, you may provide a `description` and an `alias`. While the former is used when printing the usage, the latter is used to give a single-character alias for an otherwise lengthy option. You have seen this with the alias `n` for the option `name` in the examples above.
 
-Sometimes it make sense to allow providing an option more than once. For that, add the `multiple` option to the option definitions, and set it to `on`. This lets you provide the appropriate option value multiple times on the command line:
-
-```shell
-$ node.js app.js --name Jane Jenny
-```
-
-If instead you want to provide multiple values, but with an individual flag each, set it to `lazy`:
+Sometimes it make sense to allow providing an option more than once. For that, add the `multiple` option to the option definitions, and set it to `true`. This lets you provide the appropriate option value multiple times on the command line:
 
 ```shell
 $ node.js app.js --name Jane --name Jenny

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -10,7 +10,7 @@ const helpCommand: Command<HelpOptions> = {
       type: 'string',
       description: 'The name of the command you need help for.',
       defaultOption: true,
-      multiple: 'on',
+      multiple: true,
       isRequired: false
     }
   ],

--- a/lib/convertOptionDefinition.ts
+++ b/lib/convertOptionDefinition.ts
@@ -30,8 +30,7 @@ const convertOptionDefinition = function ({ optionDefinition }: {
     alias: optionDefinition.alias,
     defaultOption: optionDefinition.defaultOption,
     defaultValue: optionDefinition.defaultValue,
-    multiple: optionDefinition.multiple === 'on',
-    lazyMultiple: optionDefinition.multiple === 'lazy',
+    lazyMultiple: optionDefinition.multiple === true,
     type
   };
 };

--- a/lib/elements/OptionDefinition.ts
+++ b/lib/elements/OptionDefinition.ts
@@ -3,7 +3,7 @@ export interface OptionDefinition {
   type: 'boolean' | 'number' | 'string';
   description?: string;
   alias?: string;
-  multiple?: 'off' | 'on' | 'lazy';
+  multiple?: boolean;
   defaultOption?: boolean;
   defaultValue?: any;
   parameterName?: string;

--- a/lib/usage/optionToString.ts
+++ b/lib/usage/optionToString.ts
@@ -1,17 +1,16 @@
-import { OptionDefinition } from '../elements/OptionDefinition';
+import { OptionDefinition } from '..';
 
 const optionToString = ({ option }: {
   option: OptionDefinition;
 }): string => {
+  const optionSegment = option.defaultOption ? `[--${option.name}]` : `--${option.name}`;
+
   const parameterName = option.parameterName ?? option.type;
-  const multiplier = option.multiple === undefined || option.multiple === 'off' ? '' : '[]';
-  const parameterDescription = option.type === 'boolean' ? '' : `{underline ${parameterName}${multiplier}}`;
+  const parameterDescriptionSegment = option.type === 'boolean' ? '' : `{underline ${parameterName}}`;
 
-  if (option.defaultOption) {
-    return `[--${option.name}] ${parameterDescription}`;
-  }
+  const multiplierSegment = !option.multiple ? '' : `[${optionSegment} ...]`;
 
-  return `--${option.name}${parameterDescription ? ' ' : ''}${parameterDescription}`;
+  return `${optionSegment} ${parameterDescriptionSegment} ${multiplierSegment}`.replace(/ +/gu, ' ').trim();
 };
 
 export { optionToString };

--- a/test/shared/examples/docker/commands/image/ls.ts
+++ b/test/shared/examples/docker/commands/image/ls.ts
@@ -46,7 +46,7 @@ const ls: Command<LsOptions> = {
       name: 'image',
       description: '',
       type: 'string',
-      multiple: 'on',
+      multiple: true,
       defaultOption: true,
       isRequired: true,
       parameterName: 'IMAGE'

--- a/test/shared/examples/docker/commands/image/rm.ts
+++ b/test/shared/examples/docker/commands/image/rm.ts
@@ -22,7 +22,7 @@ const rm: Command<RmOptions> = {
       name: 'image',
       description: '',
       type: 'string',
-      multiple: 'on',
+      multiple: true,
       defaultOption: true
     }
   ],

--- a/test/shared/examples/docker/commands/volume/create.ts
+++ b/test/shared/examples/docker/commands/volume/create.ts
@@ -22,7 +22,7 @@ const create: Command<CreateOptions> = {
       description: 'Set driver specific options.',
       type: 'string',
       alias: 'o',
-      multiple: 'on',
+      multiple: true,
       defaultValue: []
     },
     {

--- a/test/shared/examples/docker/commands/volume/inspect.ts
+++ b/test/shared/examples/docker/commands/volume/inspect.ts
@@ -14,7 +14,7 @@ const inspect: Command<InspectOptions> = {
     {
       name: 'volume',
       type: 'string',
-      multiple: 'on',
+      multiple: true,
       defaultOption: true,
       isRequired: true,
       parameterName: 'VOLUME'

--- a/test/unit/usage/getCommandLineUsageConfigurationTests.ts
+++ b/test/unit/usage/getCommandLineUsageConfigurationTests.ts
@@ -41,7 +41,7 @@ suite('getCommandLineUsageConfiguration', (): void => {
           name: 'test',
           defaultOption: true,
           parameterName: 'param',
-          multiple: 'on',
+          multiple: true,
           type: 'string'
         }
       ],
@@ -69,8 +69,7 @@ suite('getCommandLineUsageConfiguration', (): void => {
             alias: undefined,
             defaultOption: true,
             defaultValue: undefined,
-            multiple: true,
-            lazyMultiple: false,
+            lazyMultiple: true,
             typeLabel: `{underline param}`
           }
         ]
@@ -91,7 +90,7 @@ suite('getCommandLineUsageConfiguration', (): void => {
           name: 'test',
           defaultOption: true,
           parameterName: 'param',
-          multiple: 'on',
+          multiple: true,
           type: 'string'
         }
       ],
@@ -129,8 +128,7 @@ suite('getCommandLineUsageConfiguration', (): void => {
             alias: undefined,
             defaultOption: true,
             defaultValue: undefined,
-            multiple: true,
-            lazyMultiple: false,
+            lazyMultiple: true,
             typeLabel: `{underline param}`
           }
         ]

--- a/test/unit/usage/getCommandSynopsisTests.ts
+++ b/test/unit/usage/getCommandSynopsisTests.ts
@@ -111,7 +111,7 @@ suite('getCommandSynopsis', (): void => {
           {
             name: 'format',
             type: 'string',
-            multiple: 'on',
+            multiple: true,
             isRequired: true
           }
         ],
@@ -122,7 +122,7 @@ suite('getCommandSynopsis', (): void => {
 
       const synopsis = getCommandSynopsis({ command });
 
-      assert.that(synopsis).is.equalTo('test --format {underline string[]}');
+      assert.that(synopsis).is.equalTo('test --format {underline string} [--format ...]');
     });
 
     test('a required string parameter with parameter name.', async (): Promise<void> => {
@@ -198,7 +198,7 @@ suite('getCommandSynopsis', (): void => {
           {
             name: 'format',
             type: 'number',
-            multiple: 'on',
+            multiple: true,
             isRequired: true
           }
         ],
@@ -209,7 +209,7 @@ suite('getCommandSynopsis', (): void => {
 
       const synopsis = getCommandSynopsis({ command });
 
-      assert.that(synopsis).is.equalTo('test --format {underline number[]}');
+      assert.that(synopsis).is.equalTo('test --format {underline number} [--format ...]');
     });
 
     test('a required number parameter with parameter name.', async (): Promise<void> => {

--- a/test/unit/usage/optionToStringTests.ts
+++ b/test/unit/usage/optionToStringTests.ts
@@ -8,7 +8,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: undefined,
-      multiple: 'off',
+      multiple: false,
       type: 'boolean'
     };
 
@@ -22,7 +22,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: undefined,
-      multiple: 'off',
+      multiple: false,
       type: 'string'
     };
 
@@ -36,7 +36,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: undefined,
-      multiple: 'off',
+      multiple: false,
       type: 'number'
     };
 
@@ -50,13 +50,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: undefined,
-      multiple: 'on',
+      multiple: true,
       type: 'boolean'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('--test');
+    assert.that(optionString).is.equalTo('--test [--test ...]');
   });
 
   test('not default, without parameter name, with multiplier, string.', async (): Promise<void> => {
@@ -64,13 +64,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: undefined,
-      multiple: 'on',
+      multiple: true,
       type: 'string'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('--test {underline string[]}');
+    assert.that(optionString).is.equalTo('--test {underline string} [--test ...]');
   });
 
   test('not default, without parameter name, with multiplier, number.', async (): Promise<void> => {
@@ -78,13 +78,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: undefined,
-      multiple: 'on',
+      multiple: true,
       type: 'number'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('--test {underline number[]}');
+    assert.that(optionString).is.equalTo('--test {underline number} [--test ...]');
   });
 
   test('not default, with parameter name, without multiplier, boolean.', async (): Promise<void> => {
@@ -92,7 +92,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: 'param',
-      multiple: 'off',
+      multiple: false,
       type: 'boolean'
     };
 
@@ -106,7 +106,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: 'param',
-      multiple: 'off',
+      multiple: false,
       type: 'string'
     };
 
@@ -120,7 +120,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: 'param',
-      multiple: 'off',
+      multiple: false,
       type: 'number'
     };
 
@@ -134,13 +134,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: 'param',
-      multiple: 'on',
+      multiple: true,
       type: 'boolean'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('--test');
+    assert.that(optionString).is.equalTo('--test [--test ...]');
   });
 
   test('not default, with parameter name, with multiplier, string.', async (): Promise<void> => {
@@ -148,13 +148,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: 'param',
-      multiple: 'on',
+      multiple: true,
       type: 'string'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('--test {underline param[]}');
+    assert.that(optionString).is.equalTo('--test {underline param} [--test ...]');
   });
 
   test('not default, with parameter name, with multiplier, number.', async (): Promise<void> => {
@@ -162,13 +162,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: false,
       parameterName: 'param',
-      multiple: 'on',
+      multiple: true,
       type: 'number'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('--test {underline param[]}');
+    assert.that(optionString).is.equalTo('--test {underline param} [--test ...]');
   });
 
   test('default, without parameter name, without multiplier, string.', async (): Promise<void> => {
@@ -176,7 +176,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: undefined,
-      multiple: 'off',
+      multiple: false,
       type: 'string'
     };
 
@@ -190,7 +190,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: undefined,
-      multiple: 'off',
+      multiple: false,
       type: 'number'
     };
 
@@ -204,13 +204,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: undefined,
-      multiple: 'on',
+      multiple: true,
       type: 'string'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('[--test] {underline string[]}');
+    assert.that(optionString).is.equalTo('[--test] {underline string} [[--test] ...]');
   });
 
   test('default, without parameter name, with multiplier, number.', async (): Promise<void> => {
@@ -218,13 +218,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: undefined,
-      multiple: 'on',
+      multiple: true,
       type: 'number'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('[--test] {underline number[]}');
+    assert.that(optionString).is.equalTo('[--test] {underline number} [[--test] ...]');
   });
 
   test('default, with parameter name, without multiplier, string.', async (): Promise<void> => {
@@ -232,7 +232,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: 'param',
-      multiple: 'off',
+      multiple: false,
       type: 'string'
     };
 
@@ -246,7 +246,7 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: 'param',
-      multiple: 'off',
+      multiple: false,
       type: 'number'
     };
 
@@ -260,13 +260,13 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: 'param',
-      multiple: 'on',
+      multiple: true,
       type: 'string'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('[--test] {underline param[]}');
+    assert.that(optionString).is.equalTo('[--test] {underline param} [[--test] ...]');
   });
 
   test('default, with parameter name, with multiplier, number.', async (): Promise<void> => {
@@ -274,12 +274,12 @@ suite('optionToString', (): void => {
       name: 'test',
       defaultOption: true,
       parameterName: 'param',
-      multiple: 'on',
+      multiple: true,
       type: 'number'
     };
 
     const optionString = optionToString({ option });
 
-    assert.that(optionString).is.equalTo('[--test] {underline param[]}');
+    assert.that(optionString).is.equalTo('[--test] {underline param} [[--test] ...]');
   });
 });


### PR DESCRIPTION
BREAKING CHANGE:

This changes the type of the `multiple` field in the type
`OptionDefinition`. It also changes its behavior. "multiple-options" new
have to be preceded by their option name each time they are given (unless they are
default options).

This closes #245.