### PR TITLE
fix: update defekt

### DIFF
--- a/lib/convertOptionDefinition.ts
+++ b/lib/convertOptionDefinition.ts
@@ -1,6 +1,6 @@
 import { OptionDefinition as CLAOptionDefinition } from 'command-line-args';
-import { errors } from './errors';
 import { OptionDefinition } from './elements/OptionDefinition';
+import * as errors from './errors';
 
 const convertOptionDefinition = function ({ optionDefinition }: {
   optionDefinition: OptionDefinition;

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,11 +1,15 @@
 import { defekt } from 'defekt';
 
-const errors = defekt({
-  CommandNotFound: {},
-  InvalidOperation: {},
-  NoSuggestionAvailable: {},
-  OptionInvalid: {},
-  OptionMissing: {}
-});
+class CommandNotFound extends defekt({ code: 'CommandNotFound' }) {}
+class InvalidOperation extends defekt({ code: 'InvalidOperation' }) {}
+class NoSuggestionAvailable extends defekt({ code: 'NoSuggestionAvailable' }) {}
+class OptionInvalid extends defekt({ code: 'OptionInvalid' }) {}
+class OptionMissing extends defekt({ code: 'OptionMissing' }) {}
 
-export { errors };
+export {
+  CommandNotFound,
+  InvalidOperation,
+  NoSuggestionAvailable,
+  OptionInvalid,
+  OptionMissing
+};

--- a/lib/getCommandByPath.ts
+++ b/lib/getCommandByPath.ts
@@ -1,6 +1,6 @@
 import { Command } from './elements/Command';
 import { CommandPath } from './elements/CommandPath';
-import { errors } from './errors';
+import * as errors from './errors';
 
 const getCommandByPath = function ({ rootCommand, commandPath }: {
   rootCommand: Command<any>;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@ import { GetUsageFn } from './elements/GetUsageFn';
 import { Handlers } from './Handlers';
 import { OptionDefinition } from './elements/OptionDefinition';
 import { runCli } from './runCli';
+import * as errors from './errors';
 
 export {
   runCli,
@@ -13,6 +14,7 @@ export {
   CommandHandle,
   CommandHandleOptions,
   CommandPath,
+  errors,
   GetUsageFn,
   Handlers,
   OptionDefinition

--- a/lib/recommend/recommendCommand.ts
+++ b/lib/recommend/recommendCommand.ts
@@ -1,8 +1,8 @@
 import { Command } from '../elements/Command';
 import { CommandPath } from '../elements/CommandPath';
-import { errors } from '../errors';
 import { getCommandByPath } from '../getCommandByPath';
 import stringSimilarity from 'string-similarity';
+import * as errors from '../errors';
 
 const recommendCommand = function ({ rootCommand, commandPath }: {
   rootCommand: Command<any>;

--- a/lib/runCliRecursive.ts
+++ b/lib/runCliRecursive.ts
@@ -9,6 +9,7 @@ import { helpOption } from './commands/helpOption';
 import { RecommendCommandFn } from './elements/RecommendCommandFn';
 import { validateOptions } from './validateOptions';
 import commandLineArgs, { OptionDefinition as CLAOptionDefinition } from 'command-line-args';
+import * as errors from './errors';
 
 const runCliRecursive = async function ({
   command,
@@ -52,12 +53,12 @@ const runCliRecursive = async function ({
     validateOptions({ options, optionDefinitions: command.optionDefinitions });
   } catch (ex: unknown) {
     switch ((ex as CustomError).code) {
-      case 'EOPTIONMISSING':
+      case errors.OptionMissing.code:
         handlers.optionMissing({ optionDefinition: (ex as CustomError).data.optionDefinition });
 
         // eslint-disable-next-line unicorn/no-process-exit
         return process.exit(1);
-      case 'EOPTIONINVALID': {
+      case errors.OptionInvalid.code: {
         handlers.optionInvalid({ optionDefinition: (ex as CustomError).data.optionDefinition, reason: (ex as CustomError).message });
 
         // eslint-disable-next-line unicorn/no-process-exit

--- a/lib/validateOptions.ts
+++ b/lib/validateOptions.ts
@@ -1,6 +1,6 @@
 import { CustomError } from 'defekt';
-import { errors } from './errors';
 import { OptionDefinition } from './elements/OptionDefinition';
+import * as errors from './errors';
 
 // Throws an error if any option does not match its defined type or is undefined.
 // Since command-line-args handles default values, a check for undefined-ness here
@@ -14,7 +14,8 @@ const validateOptions = function ({ options, optionDefinitions }: {
     const optionRequired = optionDefinition.isRequired ?? false;
 
     if (optionRequired && value === undefined) {
-      throw new errors.OptionMissing(`Option '${optionDefinition.name}' is missing.`, {
+      throw new errors.OptionMissing({
+        message: `Option '${optionDefinition.name}' is missing.`,
         data: { optionDefinition }
       });
     }
@@ -32,7 +33,8 @@ const validateOptions = function ({ options, optionDefinitions }: {
         }
 
         if (typeof value !== 'number' || Number.isNaN(value)) {
-          throw new errors.OptionInvalid(`Option '${optionDefinition.name}' must be a number.`, {
+          throw new errors.OptionInvalid({
+            message: `Option '${optionDefinition.name}' must be a number.`,
             data: { optionDefinition }
           });
         }
@@ -47,7 +49,8 @@ const validateOptions = function ({ options, optionDefinitions }: {
       try {
         optionDefinition.validate(value);
       } catch (ex: unknown) {
-        throw new errors.OptionInvalid((ex as CustomError).message, {
+        throw new errors.OptionInvalid({
+          message: (ex as CustomError).message,
           data: { optionDefinition }
         });
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,9 +1929,9 @@
       }
     },
     "defekt": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
-      "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/defekt/-/defekt-7.0.4.tgz",
+      "integrity": "sha512-6+70JzdjQigN9WHFWrWgQGcbpn0YsTUj7moJBBX+3gMeWUnavnK0aOTD5IMOkPAy+emPETtn1//3WyT5aO4XzQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -8990,6 +8990,12 @@
         "typescript": "4.2.3"
       },
       "dependencies": {
+        "defekt": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
+          "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA==",
+          "dev": true
+        },
         "globby": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     {
       "name": "David Losert",
       "email": "david@david-losert.com"
+    },
+    {
+      "name": "Noah Hummel",
+      "email": "noah.hummel@thenativeweb.io"
     }
   ],
   "main": "build/lib/index.js",
@@ -26,7 +30,7 @@
     "command-line-args": "5.1.1",
     "command-line-commands": "3.0.2",
     "command-line-usage": "6.1.1",
-    "defekt": "6.0.2",
+    "defekt": "7.0.4",
     "string-similarity": "4.0.4",
     "strip-indent": "3.0.0"
   },

--- a/test/unit/getCommandByPathTests.ts
+++ b/test/unit/getCommandByPathTests.ts
@@ -2,6 +2,7 @@ import { assert } from 'assertthat';
 import { Command } from '../../lib/elements/Command';
 import { CustomError } from 'defekt';
 import { getCommandByPath } from '../../lib/getCommandByPath';
+import * as errors from '../../lib/errors';
 
 suite('getCommandByPath', (): void => {
   const rootCommand: Command<any> = {
@@ -94,7 +95,7 @@ suite('getCommandByPath', (): void => {
 
     assert.that((): any => getCommandByPath({ rootCommand, commandPath })).
       is.throwing(
-        (ex): boolean => (ex as CustomError).code === 'EINVALIDOPERATION'
+        (ex): boolean => (ex as CustomError).code === errors.InvalidOperation.code
       );
   });
 
@@ -103,7 +104,7 @@ suite('getCommandByPath', (): void => {
 
     assert.that((): any => getCommandByPath({ rootCommand, commandPath })).
       is.throwing(
-        (ex): boolean => (ex as CustomError).code === 'ECOMMANDNOTFOUND'
+        (ex): boolean => (ex as CustomError).code === errors.CommandNotFound.code
       );
   });
 
@@ -112,7 +113,7 @@ suite('getCommandByPath', (): void => {
 
     assert.that((): any => getCommandByPath({ rootCommand, commandPath })).
       is.throwing(
-        (ex): boolean => (ex as CustomError).code === 'ECOMMANDNOTFOUND'
+        (ex): boolean => (ex as CustomError).code === errors.CommandNotFound.code
       );
   });
 });

--- a/test/unit/recommend/recommendCommandTests.ts
+++ b/test/unit/recommend/recommendCommandTests.ts
@@ -2,6 +2,7 @@ import { assert } from 'assertthat';
 import { Command } from '../../../lib/elements/Command';
 import { CustomError } from 'defekt';
 import { recommendCommand } from '../../../lib/recommend/recommendCommand';
+import * as errors from '../../../lib/errors';
 
 suite('recommendCommand', (): void => {
   const rootCommand: Command<any> = {
@@ -44,7 +45,7 @@ suite('recommendCommand', (): void => {
 
     assert.that((): any => recommendCommand({ rootCommand, commandPath })).
       is.throwing(
-        (ex): boolean => (ex as CustomError).code === 'ENOSUGGESTIONAVAILABLE'
+        (ex): boolean => (ex as CustomError).code === errors.NoSuggestionAvailable.code
       );
   });
 });

--- a/test/unit/validateOptionsTests.ts
+++ b/test/unit/validateOptionsTests.ts
@@ -2,6 +2,7 @@ import { assert } from 'assertthat';
 import { CustomError } from 'defekt';
 import { OptionDefinition } from '../../lib';
 import { validateOptions } from 'lib/validateOptions';
+import * as errors from '../../lib/errors';
 
 suite('validateOptions', (): void => {
   suite('required', (): void => {
@@ -21,7 +22,7 @@ suite('validateOptions', (): void => {
         validateOptions({ options, optionDefinitions });
       }).is.throwing((ex): boolean =>
         ex.message === `Option 'option' is missing.` &&
-        (ex as CustomError).code === 'EOPTIONMISSING');
+        (ex as CustomError).code === errors.OptionMissing.code);
     });
   });
 
@@ -110,7 +111,7 @@ suite('validateOptions', (): void => {
         validateOptions({ options, optionDefinitions });
       }).is.throwing((ex): boolean =>
         ex.message === `Option 'option' must be a number.` &&
-        (ex as CustomError).code === 'EOPTIONINVALID');
+        (ex as CustomError).code === errors.OptionInvalid.code);
     });
   });
 
@@ -134,7 +135,7 @@ suite('validateOptions', (): void => {
         validateOptions({ options, optionDefinitions });
       }).is.throwing((ex): boolean =>
         ex.message === `Invalid value.` &&
-        (ex as CustomError).code === 'EOPTIONINVALID');
+        (ex as CustomError).code === errors.OptionInvalid.code);
     });
 
     test('does not throw an exception for required options if validate succeeds.', async (): Promise<void> => {
@@ -176,7 +177,7 @@ suite('validateOptions', (): void => {
         validateOptions({ options, optionDefinitions });
       }).is.throwing((ex): boolean =>
         ex.message === `Invalid value.` &&
-        (ex as CustomError).code === 'EOPTIONINVALID');
+        (ex as CustomError).code === errors.OptionInvalid.code);
     });
 
     test('does not throw an exception for optional options if the value is missing.', async (): Promise<void> => {


### PR DESCRIPTION
BREAKING CHANGE

The errors thrown by the library have changed, if you relied on their error codes before, you have to use the exported errors.