### PR TITLE
fix: Only allow default options in leaf commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ If you want to give a dedicated name to an option's parameter, you can set it us
 
 You can also define whether an option is the default option of a command by setting the `defaultOption` property to `true`. In this case you can skip the option's name, and just provide its value.
 
+*Note that only commands that don't have sub-commands can have a `defaultOption`. This limitation exists, because default options might otherwise conflict with sub-commands.*
+
 Last but not least, you may specify a `validate` function for an option definition. Inside this function you are free to do whatever you need to do to ensure that the option's given value is valid. However, if you throw an exception from within this function, command-line-interface aborts the command's execution, and shows an error message:
 
 ```javascript

--- a/lib/runCli.ts
+++ b/lib/runCli.ts
@@ -4,6 +4,7 @@ import { getGetUsage } from './usage/getGetUsage';
 import { getRecommendCommand } from './recommend/getRecommendCommand';
 import { Handlers } from './Handlers';
 import { runCliRecursive } from './runCliRecursive';
+import { validateOnlyLeafCommandsHaveDefaultOptions } from './validateOnlyLeafCommandsHaveDefaultOptions';
 
 const runCli = async function ({ rootCommand, argv, handlers = {}}: {
   rootCommand: Command<any>;
@@ -33,6 +34,10 @@ const runCli = async function ({ rootCommand, argv, handlers = {}}: {
     },
     ...handlers
   };
+
+  validateOnlyLeafCommandsHaveDefaultOptions({
+    command: rootCommand
+  });
 
   const extendedRootCommand = addHelpCommandToCli({ rootCommand });
 

--- a/lib/validateOnlyLeafCommandsHaveDefaultOptions.ts
+++ b/lib/validateOnlyLeafCommandsHaveDefaultOptions.ts
@@ -1,0 +1,34 @@
+import { Command } from './elements/Command';
+import * as errors from './errors';
+
+const validateOnlyLeafCommandsHaveDefaultOptions = function ({ command, ancestorNames = []}: {
+  command: Command<any>;
+  ancestorNames?: string[];
+}): void {
+  if (
+    !('subcommands' in command) ||
+    command.subcommands === undefined ||
+    Object.keys(command.subcommands).length === 0
+  ) {
+    return;
+  }
+
+  const commandPath = [ ...ancestorNames, command.name ];
+
+  for (const optionDefinition of command.optionDefinitions) {
+    if (optionDefinition.defaultOption === true) {
+      throw new errors.OptionInvalid(`Option '${optionDefinition.name}' in command '${commandPath.join(' ')}' may not be a default option, since the command has sub-commands.`);
+    }
+  }
+
+  for (const subCommand of Object.values(command.subcommands)) {
+    validateOnlyLeafCommandsHaveDefaultOptions({
+      command: subCommand,
+      ancestorNames: commandPath
+    });
+  }
+};
+
+export {
+  validateOnlyLeafCommandsHaveDefaultOptions
+};

--- a/test/unit/elements/CommandTests.ts
+++ b/test/unit/elements/CommandTests.ts
@@ -1,0 +1,39 @@
+import { assert } from 'assertthat';
+import { Command, runCli } from '../../../lib';
+
+suite('Command', (): void => {
+  test('intermediary command can not have a default option.', async (): Promise<void> => {
+    const command: Command<any> = {
+      name: 'test',
+      description: '',
+      optionDefinitions: [
+        {
+          name: 'format',
+          type: 'number',
+          isRequired: true,
+          defaultOption: true
+        }
+      ],
+      handle (): void {
+        // Intentionally left empty.
+      },
+      subcommands: {
+        foobar: {
+          name: 'foobar',
+          description: '',
+          optionDefinitions: [],
+          handle (): void {
+            // Intentionally left empty.
+          }
+        }
+      }
+    };
+
+    await assert.that(async (): Promise<void> => {
+      await runCli({
+        rootCommand: command,
+        argv: [ '--format', '100' ]
+      });
+    }).is.throwingAsync(`Option 'format' in command 'test' may not be a default option, since the command has sub-commands.`);
+  });
+});


### PR DESCRIPTION
BREAKING CHANGE: Commands with sub-commands can not define default options anymore.

This resolves #248.